### PR TITLE
Fix pi1.5oldkernel

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -144,7 +144,7 @@ device_chroot_tweaks_pre() {
                 [5.10.90]="9a09c1dcd4fae55422085ab6a87cc650e68c4181|master|1512" 
 	)
 	# Version we want
-	KERNEL_VERSION="5.10.90"
+	KERNEL_VERSION="5.4.83"
 
 	# For bleeding edge, check what is the latest on offer
 	# Things *might* break, so you are warned!

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -193,6 +193,16 @@ device_chroot_tweaks_pre() {
 		rm -rf "/lib/modules/${KERNEL_VERSION}-v8+"
 	fi
 
+        ### Temporary fix for Rasbperry PI 1.5 
+        ### Important: remove this when kernel > 5.10.80
+        ### We use this as kernel 5.10.89 does not work with some USB DACs preventing latest kernel to be used 
+        log "Downloading Firmware to support PI4 v 1.5"
+        wget -O /boot/start4.elf https://github.com/raspberrypi/firmware/raw/165bd7bc5622ee1c721aa5da9af68935075abedd/boot/start4.elf
+        wget -O /boot/start4cd.elf https://github.com/raspberrypi/firmware/raw/165bd7bc5622ee1c721aa5da9af68935075abedd/boot/start4cd.elf
+        wget -O /boot/start4db.elf https://github.com/raspberrypi/firmware/raw/165bd7bc5622ee1c721aa5da9af68935075abedd/boot/start4db.elf
+        wget -O /boot/start4x.elf https://github.com/raspberrypi/firmware/raw/165bd7bc5622ee1c721aa5da9af68935075abedd/boot/start4x.elf
+
+
 	log "Finished Kernel installation" "okay"
 
 	### Other Rpi specific stuff


### PR DESCRIPTION
Revert to old kernel 5.4.X since 5.10.89 breaks some USB Audio devices, and the Wi-Fi drivers from Mr Engman are not avialable yet.

To make it compatible with PI 1.5 version, we manually donwload the start4 elfs 