### PR TITLE
enable "Restart=on-failure" for shairport-sync

### DIFF
--- a/volumio/lib/systemd/system/shairport-sync.service
+++ b/volumio/lib/systemd/system/shairport-sync.service
@@ -10,5 +10,6 @@ After=network.target network-online.target
 ExecStart=/usr/bin/shairport-sync --configfile=/tmp/shairport-sync.conf
 User=shairport-sync
 Group=shairport-sync
+Restart=on-failure
 
 [Install]


### PR DESCRIPTION
I've run into a scenario which crashes shairport-sync.

1. Connect to Volumio AirPlay from two devices.
2. Play audio from both devices.

As seen in [this log](http://logs.volumio.org/volumio/jVlsdh4.html), this crashes shairport-sync with a segfault. Currently, nothing starts it back up except a reboot. With this configuration change, shairport-sync will automatically restart. (Presumably there's some bug in shairport-sync itself, but I'm less interested in fixing that than I am in making Volumio robust to it.)

Please let me know if there's anything else I can do to help. Thanks so much!