### PR TITLE
Add fruit:model AirPort to smb.conf

### DIFF
--- a/volumio/etc/samba/smb.conf
+++ b/volumio/etc/samba/smb.conf
@@ -9,6 +9,7 @@ wins support = yes
 local master = no
 preferred master = no
 os level = 30
+fruit:model = AirPort
 
 [Internal Storage]
         comment = Volumio Internal Music Folder


### PR DESCRIPTION
Adding fruit:model = AirPort  to smb.conf allows MacOS devices to show a more pleasing icon in Finder instead of a generic one.