### PR TITLE
[raspberry] Fix unreachable code

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -194,7 +194,7 @@ device_chroot_tweaks_pre() {
 		rm -rf "/lib/modules/${KERNEL_VERSION}-v8+"
 	fi
 
-        if [ "$ KERNEL_VERSION" = "5.4.83" ]; then
+        if [[ "${KERNEL_VERSION}" = "5.4.83" ]]; then
           ### Temporary fix for Rasbperry PI 1.5
           ### We use this as kernel 5.10.89 does not work with some USB DACs preventing latest kernel to be used
           log "Downloading Firmware to support PI4 v 1.5"


### PR DESCRIPTION
Not sure if this is still relevant, but that conditional would never have been triggered.. ;)
From 2e3149f9e2dd0578e36cfb9ce7325cbbf260be06 - it seems and no longer required, can it all go? 

If you really needed `5.4.83` support, you never would have gotten it with the current check...
