### PR TITLE
Fix wireless power on wext-only drivers

### DIFF
--- a/volumio/lib/systemd/system/wireless.service
+++ b/volumio/lib/systemd/system/wireless.service
@@ -5,6 +5,7 @@ Before=volumio.service
 [Service]
 Type=forking
 ExecStartPost=-/sbin/iw dev wlan0 set power_save off
+ExecStartPost=-/sbin/iwconfig wlan0 power off
 ExecStart=/volumio/app/plugins/system_controller/network/wireless.js start
 KillMode=mixed
 

--- a/volumio/lib/systemd/system/wireless.service
+++ b/volumio/lib/systemd/system/wireless.service
@@ -4,7 +4,7 @@ Before=volumio.service
 
 [Service]
 Type=forking
-ExecStartPost=/sbin/iw dev wlan0 set power_save off
+ExecStartPost=-/sbin/iw dev wlan0 set power_save off
 ExecStart=/volumio/app/plugins/system_controller/network/wireless.js start
 KillMode=mixed
 


### PR DESCRIPTION
Not all wifi drivers have been switched from wext to cfg80211/nl80211 (used by`iw`). And not all nl80211 compatible wifi drivers support the power_save configuration. On these kind of devices, the service would fail due to the exit code of the command in ExecStartPost. And since it wasn't an optional (ignoring exit code), the wireless.js daemon would also be stopped by systemd. As result, the wireless would work for some time but at some point suddenly stop working. For after 24h - when the killed child `dhcpcd` is not refreshing the received IP again and Linux is removing the IP address based on its `valid_lft`.
    
Since the disabling of powersave is not mission-critical, making it an optional command (which can fail without stopping the service) leads to the more desirable outcome: wireless.js with all its started children (`wpa_supplicant`, `dhcpcd`) are still running.

And for wext-only drivers, just trying to run `iwconfig .. power off` to disable powersave can also be used (sometimes) to disable the powersave feature on legacy drivers. And since the return code of this command is ignored, it will not stop the wireless.js service in case it fails.