### PR TITLE
Nanopi Neo2/3: Add 'net.ifnames=0' to kernel parameters

### DIFF
--- a/recipes/devices/nanopineo2.sh
+++ b/recipes/devices/nanopineo2.sh
@@ -42,9 +42,13 @@ write_device_files() {
   log "Running write_device_files" "ext"
 
   cp -dR "${PLTDIR}/${DEVICEBASE}/boot" "${ROOTFSMNT}"
+
   cp -pdR "${PLTDIR}/${DEVICEBASE}/lib/modules" "${ROOTFSMNT}/lib"
   cp -pdR "${PLTDIR}/${DEVICEBASE}/lib/firmware" "${ROOTFSMNT}/lib"
 
+  # Volumio 3 needs predictable device naming switched off
+  # Use a volumio3-specific version which adds "net.ifnames=0" to the kernel parameters
+  cp "${PLTDIR}/${DEVICEBASE}/boot/boot.cmd.volumio-os3" "${ROOTFSMNT}/boot/boot.cmd"
 }
 
 write_device_bootloader() {

--- a/recipes/devices/nanopineo3.sh
+++ b/recipes/devices/nanopineo3.sh
@@ -78,7 +78,7 @@ label kernel-5.4
     kernel /Image
     fdt /rk3328-nanopi-neo3-rev02.dtb
     initrd /uInitrd
-    append  earlycon=uart8250,mmio32,0xff130000 console=ttyS2,1500000 console=tty1 imgpart=/dev/mmcblk0p2 imgfile=/volumio_current.sqsh hwdevice=nanopineo3 bootdev=mmcblk0
+    append  earlycon=uart8250,mmio32,0xff130000 console=ttyS2,1500000 console=tty1 imgpart=/dev/mmcblk0p2 imgfile=/volumio_current.sqsh hwdevice=nanopineo3 bootdev=mmcblk0 net.ifnames=0
 EOF
 
   log "Changing to 'modules=list' to limit uInitrd size"


### PR DESCRIPTION
Disabling "Predictable Device Names" on wlan, seems eth was not affected.