### PR TITLE
SND-USB-AUDIO: Removed nrpacks as the option is not supported anymore

### DIFF
--- a/volumio/etc/modprobe.d/alsa-base.conf
+++ b/volumio/etc/modprobe.d/alsa-base.conf
@@ -21,8 +21,6 @@ options cx88_alsa index=-2
 options snd-atiixp-modem index=-2
 options snd-intel8x0m index=-2
 options snd-via82xx-modem index=-2
-#Tuning USB devices for minimal latencies
-options snd-usb-audio nrpacks=1
 # USB DACs will have device number 5 in whole Volumio device range
 options snd-usb-audio index=5
  


### PR DESCRIPTION
The snd-usb-audio module does not support the `nrpacks` option anymore for quite some time now.

See this patch from 2013: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=976b6c0

Looking at `dmesg` output, you will find
```
[   xx.yyyyyy] snd_usb_audio: unknown parameter 'nrpacks' ignored
```

So this patch removes setting this options in the `/etc/modprobe.d/alsa-base.conf`.
