### PR TITLE
x86_amd64: make kernel and firmware version selection flexible

### DIFF
--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -54,27 +54,34 @@ MODULES=("overlay" "squashfs"
 # Packages that will be installed
 PACKAGES=()
 
+# Copy in the kernel version we are interested in
+# This will be expanded as a glob, you can be as specific or vague as required
+# KERNEL_VERSION=5.10
+KERNEL_VERSION=6.1
+# KERNEL_VERSION=6.6
+
+# Copy in the firmware version we are interested in
+# FIRMWARE_VERSION="20211027"
+# FIRMWARE_VERSION="20221216"
+FIRMWARE_VERSION="20230804"
+  
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
 write_device_files() {
   log "Running write_device_files" "ext"
   log "Copying kernel files"
   pkg_root="${PLTDIR}/packages-buster"
-  # Copy in the kernel version we are interested in
-  # This will be expanded as a glob, you can be as specific or vague as required
-  # KERNEL_VERSION=4.19
-  KERNEL_VERSION=5.10
+
   cp "${pkg_root}"/linux-image-${KERNEL_VERSION}*_${ARCH}.deb "${ROOTFSMNT}"
+
+  log "Copying header files, when present"
+  if [ -f "${pkg_root}"/linux-headers-${KERNEL_VERSION}*_${ARCH}.deb ]; then
+    cp "${pkg_root}"/linux-headers-${KERNEL_VERSION}*_${ARCH}.deb "${ROOTFSMNT}"
+  fi
+
   log "Copying the latest firmware into /lib/firmware"
-  tar xfJ "${pkg_root}"/linux-firmware-buster.tar.xz -C "${ROOTFSMNT}"
-
-  log "Copying firmware additions"
-  tar xf "${pkg_root}"/firmware-brcm-sdio-nvram/broadcom-nvram.tar.xz -C "${ROOTFSMNT}"
-  cp "${pkg_root}"/firmware-cfg80211/* "${ROOTFSMNT}"/lib/firmware
-
-  log "Copy firmware needed by the b43 kernel driver..."
-  log "... for some Broadcom 43xx wireless network cards."
-  tar xfJ "${pkg_root}"/firmware-b43/firmware-b43.tar.xz -C "${ROOTFSMNT}"/lib
+  log "Unpacking the tar file firmware-${FIRMWARE_VERSION}"
+  tar xfJ "${pkg_root}"/firmware-${FIRMWARE_VERSION}.tar.xz -C "${ROOTFSMNT}"
 
   #log "Copying Alsa Use Case Manager files"
   #With Buster we seem to have a default install, but it is not complete. Add the missing codecs.
@@ -133,18 +140,6 @@ write_device_bootloader() {
 device_image_tweaks() {
   log "Running device_image_tweaks" "ext"
 
-  log "Some wireless network drivers (e.g. for Marvell chipsets) create device 'mlan0'"
-  log "Rename these to 'wlan0' using a systemd link"
-  cat <<-EOF > "${ROOTFSMNT}/etc/systemd/network/10-rename-mlan0.link"
-[Match]
-Type=wlan
-Driver=mwifiex_sdio
-OriginalName=mlan0
-
-[Link]
-Name=wlan0
-EOF
-
   log "Add service to set sane defaults for baytrail/cherrytrail and HDA soundcards"
   cat <<-EOF >"${ROOTFSMNT}/usr/local/bin/soundcard-init.sh"
 #!/bin/sh -e
@@ -200,6 +195,15 @@ device_chroot_tweaks_pre() {
   rm -r /usr/share/doc/linux-image*
   rm linux-image-*_"${ARCH}".deb
 
+  log "Installing the headers, when present"
+  if [ -f linux-headers-*_"${ARCH}".deb ]; then
+    mkdir /tmpheaders
+    dpkg-deb -R linux-headers-*_"${ARCH}".deb ./tmpheaders
+    cp -R /tmpheaders/usr/src/linux-headers*/include /usr/src
+    rm -r /tmpheaders
+    rm linux-headers-*_"${ARCH}".deb
+  fi
+
   log "Change linux kernel image name to 'vmlinuz'"
   # Rename linux kernel to a fixed name, like we do for any other platform.
   # We only have one and we should not start multiple versions.
@@ -238,7 +242,7 @@ device_chroot_tweaks_pre() {
   )
 
   if [[ $DEBUG_IMAGE == yes ]]; then
-    log "Creaing debug image" "wrn"
+    log "Creating debug image" "wrn"
     KERNEL_LOGLEVEL="loglevel=8" # KERN_DEBUG
     kernel_params+=("debug")     # keep intiramfs logs
     log "Enabling ssh on boot"
@@ -257,7 +261,7 @@ device_chroot_tweaks_pre() {
   cat <<-EOF >/boot/syslinux.tmpl
 DEFAULT volumio
 LABEL volumio
-	SAY Booting Volumio Audiophile Music Player, please wait...
+	SAY Booting Volumio Audiophile Music Player...
   LINUX vmlinuz
   APPEND ${kernel_params[@]}
   INITRD volumio.initrd
@@ -292,7 +296,6 @@ EOF
   log "Notebook-specific: ignore 'cover closed' event"
   sed -i "s/#HandleLidSwitch=suspend/HandleLidSwitch=ignore/g" /etc/systemd/logind.conf
   sed -i "s/#HandleLidSwitchExternalPower=suspend/HandleLidSwitchExternalPower=ignore/g" /etc/systemd/logind.conf
-
 
 }
 

--- a/recipes/devices/x86_amd64.sh
+++ b/recipes/devices/x86_amd64.sh
@@ -12,4 +12,5 @@ source "${SRC}"/recipes/devices/families/x86.sh
 # Base system
 ARCH="amd64"
 BUILD="x64"
+DEVICE="x86_amd64"
 DEVICENAME="x86_64"

--- a/scripts/initramfs/init.x86
+++ b/scripts/initramfs/init.x86
@@ -256,7 +256,13 @@ fi
 # 1) mount the partition where the squash image resides
 [ -d /mnt/imgpart ] || mkdir /mnt/imgpart
 mount -t ext4 "${IMGPART}" /mnt/imgpart
-
+echo " "
+echo " "
+echo " "
+echo " "
+echo " "
+echo " "
+echo "[init] Initializing Volumio startup..."
 if [ ! -e "/mnt/imgpart/kernel_current.tar" ] || [ -e "/mnt/imgpart/current_kernel_creation" ]; then
   print_msg "Creating archive for current kernel..."
   touch /mnt/imgpart/current_kernel_creation
@@ -305,6 +311,7 @@ if [ ! -z "${BOOTDELAY}" ]; then
 fi
 
 print_msg "Checking for a volumio rootfs update on a USB device"
+
 mkdir /mnt/usb
 for devlink in /dev/sd[a-z]; do
   if [ "${devlink}" == "/dev/sd[a-z]" ]; then
@@ -317,12 +324,15 @@ for devlink in /dev/sd[a-z]; do
     mount -t vfat ${devlink}1 /mnt/usb >/dev/null 2>&1
     print_msg "Checking ${devlink}1 for a volumio rootfs update"
     if [ -e /mnt/usb/*.fir ]; then
+      echo "[init] Performing Volumio Update from USB..."
       print_msg "New rootfs firmware found"
       print_msg "Updating can take several minutes, please wait...."
       mkdir /mnt/boot
       mount -t vfat "${BOOTPART}" /mnt/boot
       volumio-init-updater
       print_msg "USB Update applied"
+      echo "[init] USB Update finished, rebooting..."
+      sleep 2
       umount /mnt/usb >/dev/null 2>&1
       rm -r /mnt/boot
       rm -r /mnt/usb
@@ -369,6 +379,7 @@ print_msg "Checking for factory or user-data reset on boot device"
 mkdir /mnt/factory
 mount -t vfat "${BOOTPART}" /mnt/factory
 if [ -e "/mnt/factory/user_data" ]; then
+  echo "[init] Performing Factory Reset..."
   print_msg "Deleting User Data..."
   #mke2fsfull is used since busybox mke2fs does not include ext4 support
   /sbin/mke2fsfull -t ext4 -F -E stride=2,stripe-width=1024 -b 4096 "${DATAPART}" -L volumio_data >/dev/null 2>&1
@@ -401,7 +412,9 @@ fi
 # These need to be edited into the new boot configs to make the new update bootable
 # This is an update on an existing installation, do not resize the data partition
 # Just remove the sentinel
+
 if [ -e "/boot/kernel_update" ]; then
+  echo "[init] Performing Volumio update..."
   print_msg "unpacking kernel"
   tar xf /mnt/imgpart/kernel_current.tar -C /boot
   #TODO: Will the second mounting of BOOTPART fail?
@@ -410,6 +423,8 @@ if [ -e "/boot/kernel_update" ]; then
   rm /boot/kernel_update
   umount /boot
   rm -rf /boot
+  echo "[init] Volumio updated, rebooting..."
+  sleep 2
   echo b >/proc/sysrq-trigger
 fi
 
@@ -421,6 +436,7 @@ DATADEV=/dev/$(lsblk -no PKNAME "${DATAPART}")
 # Re-sizing is not necessary when we already reached maximum (shows with decimals less than 1MB).
 FREESIZE="$(parted -s "${DATADEV}" unit MB print free | tail -n 2 | grep Free | awk '{print $3}' | awk -F 'MB' '{print $1}')"
 if [ "$(awk 'BEGIN {print ("'$FREESIZE'" >= "'1'")}')" -eq "1" ]; then
+  echo "[init] Re-sizing Volumio data partition..."
   print_msg "Re-sizing Volumio data partition..."
   END="$(parted -s "${DATADEV}" unit MB print free | grep Free | tail -1 | awk '{print $2}' | grep -o '[0-9]\+')"
   parted -s "${DATADEV}" resizepart 3 "${END}" >/dev/null 2>&1
@@ -487,7 +503,7 @@ if ! grep -q "^UUID=${UUID_BOOT}" /mnt/ext/union/etc/fstab; then
 fi
 print_msg "Volumio: ${VOLUMIO_VERSION}"
 print_msg "Finishing initramfs, switching rootfs and starting the boot process..."
-
+echo "[init] Volumio ${VOLUMIO_VERSION} startup initialized, please wait for Volumio to start up..."
 # Move /run to the root so our logs are there when we boot
 mount -n -o move /run /mnt/ext/union/run
 [ -f log_pipe ] && rm log_pipe


### PR DESCRIPTION
There are two parameters in recipes/devices/families/x86.sh, set to use kernel 6.1.y and newest firmware.
KERNEL_VERSION=6.1
FIRMWARE_VERSION="20230804"

Change to "6.6" and "20230804" for future Debian Bookworm
Change to "5.10" and "20221216" to revert to "older" Debian Buster
