### PR TITLE
x86: re-apply 'rename Marvell chip mlan devices to wlan'

### DIFF
--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -140,6 +140,18 @@ write_device_bootloader() {
 device_image_tweaks() {
   log "Running device_image_tweaks" "ext"
 
+  log "Some wireless network drivers (e.g. for Marvell chipsets) create device 'mlan0'"
+  log "Rename these to 'wlan0' using a systemd link"
+  cat <<-EOF > "${ROOTFSMNT}/etc/systemd/network/10-rename-mlan0.link"
+[Match]
+Type=wlan
+Driver=mwifiex_sdio
+OriginalName=mlan0
+
+[Link]
+Name=wlan0
+EOF
+
   log "Add service to set sane defaults for baytrail/cherrytrail and HDA soundcards"
   cat <<-EOF >"${ROOTFSMNT}/usr/local/bin/soundcard-init.sh"
 #!/bin/sh -e


### PR DESCRIPTION
Preparations were done for kernel 6.1.y last year, meanwhile a patch was submitted to fix wireless Marvell mlan0 devices in the families/x86.sh recipe.
This did not make it into my previous PR, this PR re-applies that patch.
