### PR TITLE
Installer: add support for rockpi-4b

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -1,19 +1,31 @@
-NOTE: The structure will likely need modification to fit in with the refactoring of the 
-build process when this has been completed.
 
-**Usage**
 
-~~~
+## Auto Installer image
+**Create**
+```
 ./mkinstaller.sh -i <location of the volumio image>
-~~~
+```
 
-where currently supported devices are  **Volumio MP1** and **Volumio Motivo**
+where currently supported devices are  **Volumio Rivo/Primo/Integro**, **Khadas VIM1S**, **Odroid N2** **Odroid M1S** and **RockPi 4B**
+
+NOTE: Due to limited image filename parsing options, the board name is only allowed to have a maximum of one single dash, like "rockpi-4b".
+With more than one, the installer will not work!
 
 
-**Build Process**
-It consists of 4 components:
+**Use**
+- Flash the Auto installer to an SD card
+- Insert the SD card in the target device
+- Power the target device
+- Wait until finished (after 30-40 secs the devices leds should be steady)
 
-*mkinstaller.sh*  
+
+## How it works
+
+Basically, the installer creates the 3 standard partitions on the target devices, as specified in the build recipe, for the data partition it takes the rest of the disk. does.  TGhen it copies the bootpartition and the image partition files. 
+
+The installer is made up of 5 components:
+
+**mkinstaller.sh**  
 This is the main build script.
 It creates an autoinstaller image with 
 - a kernel
@@ -22,30 +34,149 @@ It creates an autoinstaller image with
 - the volumiocurrent.sqsh
 - the bootloader files (u-boot)
 
-*mkinstaller_config.sh*  
-Device-specific mkinstaller configuration and  script functions
+**mkinstaller_config.sh**  
+Device-specific mkinstaller configuration and script functions
 
-*mkinitrd.sh*  
+**mkinitrd.sh**  
 A build script running in chroot.  
 It creates the runtime, board-specific initramfs, which acts as the "autoinstaller" 
 
-**Runtime Process**  
-The runtime autoinstaller is an image, which can be flashed to an SD card.  
-The image will load nothing more than a kernel and an initramfs, it does not have a rootfs.  
-The initramfs is board-specific and is made up of:   
+ 
+**initramfs**
+It is board-specific and is made up of:   
 
-*init_script*  
-This is the main init script within the initramfs.
-It mounts the boot partiton of the autoinstaller, loads the necessary modules, checks whether UUID are used and checks whether the target device has been brought up.
-It clears all existing partitions, creates the boot and imgpart partitions according to the config, and the data partiton taking the rest of the disk device.
-It mounts the 3 partitions and unpacks the boot partiton tarbal and copies the .sqsh file to the image partition. When UUIDs are used in the boot configuration, they will be replaced by the ones from the newly created partitions.
+It mounts the boot partiton of the autoinstaller, loads the necessary modules, checks whether UUID are used and checks whether the target disk device is present.
+When the target disk device is present, the installer 
+- clears all existing partitions
+- creates the boot and imgpart partitions according to the config
+- the data partiton with the remaining of the disk device
+
+It then 
+- mounts the 3 partitions 
+- in the boot partition it unpacks the boot partiton tarbal 
+- copies the .sqsh file to the image partition
+
+When UUIDs are used in the boot configuration, they will be replaced by the ones from the newly created partitions.
 
 Process start and finish will be notified by the led functions (board-specific).   
 
-*gen-functions*  
-These are generic script functions, used by the init script.   
-It is the same for each installer.
- 
-*board-functions*  
+**board-functions**  
 These are the board-specific function, used by the init scripts.
 Example: write_device_bootloader, which is different for most boards.
+
+## Installer creation ##
+
+The main part of the installer is generic, these parts are *mkinstaller.sh*, *mkinitrd.sh* (which creates the initramfs), they do not change.
+To make the installer board-specific, two specific scripts are needed, *board-functions* and "mkinstall_config.sh"
+These scripts need to be placed in the *board-config* folder, in a subfolder with the name of the board.
+To explain how this is done, the creation of an installer for the Rock Pi 4B is taken as an example and described below
+
+
+ # How to add a new installer
+
+This looks more complicated than it actually is.
+Most of the functionality is already there and creating your device-specific installer only takes two files to be copied from an existing installer and modified.
+Most of the information you need was already configured in the board's recipe.
+With this example, the Rock PI 4B, you will need the "rockpi-4b.sh" device recipe as a reference.
+
+First create folder ```rockpi-4b``` in the installer's ```board-config``` folder
+```
+installer
+  |
+  +--board-config
+      |
+      +---rockpi-4b
+```
+Note: the folder name must match the boards name as used in it's recipe.
+Then copy from any of the exisiting board configurastion the two scripts ```board-functions``` and ```mkinstall_config.sh```.
+We will use these as templates, I used the ones from odroidm1s as they came closest
+```
+installer
+  |
+  +--board-config
+      |
+      +--rockpi-4b
+          |
+          +--board-functions
+          +--mkinstall_config.sh
+```
+
+# Script ```mkinstall_config.sh```
+- Start with the ```mkinstall_config.sh``` file, you need rockpi-4b.sh as a reference.  
+Modify the following parameters, some may have the correct values already.
+
+|Parameter|New content|Comment|
+|---|---|---|
+|DEVICEBASE|rock4
+|BOARDFAMILY|rockpi-4b
+PLATFORMREPO|https://github.com/volumio/platform-${DEVICEBASE}.git"
+BOOT_START|20
+BOOT_END|148
+BOOTDEV|mmcblk0|Check this by booting from an SD card and then see which device you booted from and which one is your target disk (with eMMC it is the one with the special boot0 and boot1 partitions). Use this info for the following TARGET parameters
+BOOTDEVICE|/dev/mmcblk0p1
+BOOTCONFIG|armbianEnv.txt
+TARGETBOOT|/dev/mmcblk1p1|Used by the installer image
+TARGETDEV|/dev/mmcblk1|Used by the installer image
+TARGETDATA|dev/mmcblk1p3|Used by the installer image
+TARGETIMAGE|/dev/mmcblk1p2|Used by the installer image
+MODULES|"nls_cp437 fuse"|To be safe, match this with your build recipe. But omit overlay, overlayfs and squashfs, the installer does not need them.
+HWDEVICE|rockpi-4b|Used by the installer image
+
+- Next in ```mkinstall_config.sh```, re-write the board-specific functions.  
+For ```write_device_files()```, just copy the needed basic files for booting, no need for an overlay or any other board-specific run-time content.  
+  
+```
+write_device_files()
+{
+  cp ${PLTDIR}/${BOARDFAMILY}/boot/Image ${ROOTFSMNT}/boot
+  cp ${PLTDIR}/${BOARDFAMILY}/boot/armbianEnv.txt ${ROOTFSMNT}/boot
+  cp ${PLTDIR}/${BOARDFAMILY}/boot/boot.scr ${ROOTFSMNT}/boot
+  cp -dR ${PLTDIR}/${BOARDFAMILY}/boot/dtb ${ROOTFSMNT}/boot
+} 
+```
+- For ```write_device_bootloader()```, refer to ```rockpi-4b.sh```
+```
+write_device_bootloader()
+{
+  dd if=${PLTDIR}/${BOARDFAMILY}/u-boot/idbloader.img of=${LOOP_DEV} seek=64 conv=notrunc status=none
+  dd if=${PLTDIR}/${BOARDFAMILY}/u-boot/u-boot.itb of=${LOOP_DEV} seek=16384 conv=notrunc status=none
+}
+```
+- For ```copy_device_bootloader_files()```, refer to ```rockpi-4b.sh```
+```
+copy_device_bootloader_files()
+{
+   mkdir ${ROOTFSMNT}/boot/u-boot
+   cp ${PLTDIR}/${BOARDFAMILY}/u-boot/idbloader.img $ROOTFSMNT/boot/u-boot
+   cp ${PLTDIR}/${BOARDFAMILY}/u-boot/u-boot.itb $ROOTFSMNT/boot/u-boot
+}
+```
+- For ```write_boot_parameters()```, refer to platform template ```armbianEnv.txt```.  
+Only very basic data is needed, it is only to start into initramfs. There is no rootfs to load.
+Console information can be helpful for debugging, note that at the end of the process you can issue the "dmesg" command to check.
+```
+write_boot_parameters()
+{
+   sed -i "s/verbosity/#verbosity/g" $ROOTFSMNT/boot/armbianEnv.txt
+   sed -i "s/imgpart=UUID= bootpart=UUID= datapart=UUID= bootconfig=armbianEnv.txt imgfile=\/volumio_current.sqsh net.ifnames=0/loglevel=0/g" $ROOTFSMNT/boot/armbianEnv.txt
+   sed -i "s/user_overlays=spdif_sound//g" $ROOTFSMNT/boot/armbianEnv.txt
+}
+```  
+
+# Script ```board_functions```
+The next script to modify is ```board_functions```  
+This one has 4 script, of which only one is crucial: ```write_device_bootloader()```
+
+```
+write_device_bootloader()
+{
+   echo "[info] Flashing u-boot"
+   dd if=${BOOT}/u-boot/idbloader.img of=$1 seek=64 conv=notrunc status=none
+   dd if=${BOOT}/u-boot/u-boot.itb of=$1 seek=16384 conv=notrunc status=none
+}
+```
+
+The other 3 functions are used to play with the leds while the installer is running.
+It is very board-specific, some boards only have a power led, which you cannot even switch off. Others are a bit more flexible, most ones have at least with a heartbeat/on/off function, some have two different colored leds.  
+This part is up to someone's imagination.  
+Try to indicate at least start and stop, so the user has some idea when the process is finished.   

--- a/installer/board-config/rockpi-4b/board-functions
+++ b/installer/board-config/rockpi-4b/board-functions
@@ -1,0 +1,32 @@
+
+# Board functions RockPi 4B
+write_device_bootloader()
+{
+   echo "[info] Flashing u-boot"
+   dd if=${BOOT}/u-boot/idbloader.img of=$1 seek=64 conv=notrunc status=none
+   dd if=${BOOT}/u-boot/u-boot.itb of=$1 seek=16384 conv=notrunc status=none
+}
+
+led_show_init_signal()
+{
+   echo default-on > /sys/class/leds/blue:status/trigger
+}
+
+led_show_start_signal()
+{
+   echo heartbeat > /sys/class/leds/blue:status/trigger
+   sleep 1
+   echo none  > /sys/class/leds/blue:status/trigger
+   sleep 1
+   echo heartbeat  > /sys/class/leds/blue:status/trigger
+   sleep 1
+   echo none  > /sys/class/leds/blue:status/trigger
+   sleep 1
+   echo heartbeat  > /sys/class/leds/blue:status/trigger
+}
+
+led_show_finish_signal()
+{
+   echo default-on > /sys/class/leds/blue:status/trigger
+}
+

--- a/installer/board-config/rockpi-4b/mkinstall_config.sh
+++ b/installer/board-config/rockpi-4b/mkinstall_config.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Device Info RockPi 4B
+DEVICEBASE="rock4"
+BOARDFAMILY="rockpi-4b"
+PLATFORMREPO="https://github.com/gkkpch/platform-${DEVICEBASE}.git"
+BUILD="armv7"
+NONSTANDARD_REPO=no	# yes requires "non_standard_repo() function in make.sh 
+LBLBOOT="BOOT"
+LBLIMAGE="volumio"
+LBLDATA="volumio_data"
+
+# Partition Info
+BOOT_TYPE=msdos			# msdos or gpt   
+BOOT_START=20
+BOOT_END=148
+IMAGE_END=3800
+BOOT=/mnt/boot
+BOOTDELAY=1
+BOOTDEV="mmcblk0"
+BOOTPART=/dev/${BOOTDEV}p1
+BOOTCONFIG=armbianEnv.txt
+
+TARGETBOOT="/dev/mmcblk1p1"
+TARGETDEV="/dev/mmcblk1"
+TARGETDATA="/dev/mmcblk1p3"
+TARGETIMAGE="/dev/mmcblk1p2"
+HWDEVICE="rockpi-4b"
+USEKMSG="yes"
+UUIDFMT="yes"			# yes|no (actually, anything non-blank)
+FACTORYCOPY="yes"
+
+
+# Modules to load (as a blank separated string array)
+MODULES="nls_cp437 fuse"
+
+# Additional packages to install (as a blank separated string)
+#PACKAGES=""
+
+# initramfs type
+RAMDISK_TYPE=image		# image or gzip (ramdisk image = uInitrd, gzip compressed = volumio.initrd) 
+
+non_standard_repo()
+{
+   :
+}
+
+fetch_bootpart_uuid()
+{
+   :
+}
+
+is_dataquality_ok()
+{
+   return 0
+}
+
+write_device_files()
+{
+  cp ${PLTDIR}/${BOARDFAMILY}/boot/Image ${ROOTFSMNT}/boot
+  cp ${PLTDIR}/${BOARDFAMILY}/boot/armbianEnv.txt ${ROOTFSMNT}/boot
+  cp ${PLTDIR}/${BOARDFAMILY}/boot/boot.scr ${ROOTFSMNT}/boot
+  cp -dR ${PLTDIR}/${BOARDFAMILY}/boot/dtb ${ROOTFSMNT}/boot
+} 
+
+write_device_bootloader()
+{
+  dd if=${PLTDIR}/${BOARDFAMILY}/u-boot/idbloader.img of=${LOOP_DEV} seek=64 conv=notrunc status=none
+  dd if=${PLTDIR}/${BOARDFAMILY}/u-boot/u-boot.itb of=${LOOP_DEV} seek=16384 conv=notrunc status=none
+}
+
+copy_device_bootloader_files()
+{
+   mkdir ${ROOTFSMNT}/boot/u-boot
+   cp ${PLTDIR}/${BOARDFAMILY}/u-boot/idbloader.img $ROOTFSMNT/boot/u-boot
+   cp ${PLTDIR}/${BOARDFAMILY}/u-boot/u-boot.itb $ROOTFSMNT/boot/u-boot
+}
+
+write_boot_parameters()
+{
+   sed -i "s/verbosity/#verbosity/g" $ROOTFSMNT/boot/armbianEnv.txt
+   sed -i "s/imgpart=UUID= bootpart=UUID= datapart=UUID= bootconfig=armbianEnv.txt imgfile=\/volumio_current.sqsh net.ifnames=0/loglevel=0/g" $ROOTFSMNT/boot/armbianEnv.txt
+   sed -i "s/user_overlays=spdif_sound//g" $ROOTFSMNT/boot/armbianEnv.txt
+}
+
+
+
+

--- a/installer/runtime-generic/gen-functions
+++ b/installer/runtime-generic/gen-functions
@@ -99,12 +99,12 @@ swap_uuids()
 	export UUID_IMAGE=$(blkid -s UUID -o value ${TARGETIMAGE})
 	export UUID_DATA=$(blkid -s UUID -o value ${TARGETDATA})
 	cp $BOOT/temp/boot/$BOOTCONFIG $BOOT/temp/boot/$BOOTCONFIG.old
-cat $BOOT/temp/boot/$BOOTCONFIG >> /dev/kmsg
+
 	sed -i "s/imgpart=UUID=[a-fA-F0-9]\{8\}-[A-Fa-f0-9]\{4\}-[A-Fa-f0-9]\{4\}-[A-Fa-f0-9]\{4\}-[A-Fa-f0-9]\{12\}/imgpart=UUID=${UUID_IMAGE}/g" $BOOT/temp/boot/${BOOTCONFIG}
 	sed -i "s/datapart=UUID=[a-fA-F0-9]\{8\}-[A-Fa-f0-9]\{4\}-[A-Fa-f0-9]\{4\}-[A-Fa-f0-9]\{4\}-[A-Fa-f0-9]\{12\}/datapart=UUID=${UUID_DATA}/g" $BOOT/temp/boot/${BOOTCONFIG}
 	sed -i "s/bootpart=UUID=[a-fA-F0-9]\{4\}-[a-fA-F0-9]\{4\}/bootpart=UUID=${UUID_BOOT}/g" $BOOT/temp/boot/${BOOTCONFIG}
   sync
-cat $BOOT/temp/boot/$BOOTCONFIG >> /dev/kmsg
+
 }
 
 mount_target_boot()

--- a/installer/runtime-generic/init-script
+++ b/installer/runtime-generic/init-script
@@ -25,7 +25,7 @@ mknod /dev/tty c 5 0
 [ -e /dev/console ] || mknod /dev/console c 5 1
 
 mdev -s
-
+echo "[info] Entering installation script" >> /dev/kmsg
 echo "[info] Including config script functions" >> /dev/kmsg
 . /scripts/initconfig.sh
 . /scripts/gen-functions
@@ -62,6 +62,7 @@ create_volumio_partitions
 write_device_bootloader ${TARGETDEV}
 mount_target_boot
 
+echo "[info] Copying data..."
 echo "[info] Copying current image partition files" >> /dev/kmsg
 cp $BOOT/data/image/* $BOOT/temp/image
 
@@ -82,6 +83,7 @@ if [ ! "x${UUIDFMT}" == "x" ]; then
    swap_uuids
 fi
 
+echo "[Info] Finishing..."
 echo "[info] Syncing..." >> /dev/kmsg
 sync
 echo "[info] Remove temp folders" >> /dev/kmsg
@@ -97,6 +99,7 @@ led_show_finish_signal
 umount /proc
 umount /sys
 
+echo "[info] You can check the installation with the 'dmesg' command"
 echo "[info] Installer program finished, please manually power off the unit and remove the SD card." >> /dev/kmsg
 sh
 while true


### PR DESCRIPTION
Also includes some minor changes and optimizations.
As rockpi-4b has a dash "-" in its device name, parsing of the input image filename had to be modified.
The remaining changes are mostly cosmetic (progress/ debugging info).  