### PR TITLE
Fix upmpdcli/lesboncomptes GPG key location

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -4,7 +4,7 @@
 declare -A SecureApt=(
   [debian_10.gpg]="https://repo.volumio.org/Volumio2/archive-key-10.asc"
   [nodesource.gpg]="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
-  [lesbonscomptes.gpg]="https://www.lesbonscomptes.com/pages/jf-at-dockes.org.pub"
+  [lesbonscomptes.gpg]="https://www.lesbonscomptes.com/pages/lesbonscomptes.gpg"
   #TODO Not needed for arm64 and x86
   [raspbian.gpg]="https://archive.raspbian.org/raspbian.public.key"
   [raspberrypi.gpg]="http://archive.raspberrypi.org/debian/raspberrypi.gpg.key"


### PR DESCRIPTION
This issue fixes #110 , which is breaking building for at least pi, vim3 and mp1 (probably for all supported platforms).