### PR TITLE
Remove factory_reset sentinel after reset is prepared

### DIFF
--- a/scripts/initramfs/scripts/volumio-functions
+++ b/scripts/initramfs/scripts/volumio-functions
@@ -343,6 +343,7 @@ search_for_factory_reset() {
       if [ -e ${USBMNT}/factory_reset ]; then
         echo " " >${BOOTMNT}/user_data
         log_success_msg "Factory reset initiated"
+        rm -f ${USBMNT}/factory_reset
         umount ${USBMNT} >/dev/null 2>&1
         break
       fi


### PR DESCRIPTION
When factory_reset is left on the USB device and device is still attached it will trigger reset every time volumio device is rebooted.