### PR TITLE
Buster old init 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -206,11 +206,11 @@ function patch_multistrap_conf() {
   local type="$1"
   case "$type" in
   raspbian)
-    log "Patching multistrap config to point to Raspbian sources" "info"
+    log "Patching multistrap config to point to Raspbian sources" "info" "${APTSOURCE[Raspbian]}"
     BASECONF=recipes/base/VolumioBase.conf
     export RASPBIANCONF=recipes/base/arm-raspbian.conf
     debian_source=http://deb.debian.org/debian
-    rapsbian_source=http://mirrordirector.raspbian.org/raspbian
+    rapsbian_source="${APTSOURCE[Raspbian]}"
 
     cat <<-EOF >"${SRC}/${RASPBIANCONF}"
 		# Auto generated multistrap configuration for Raspberry Pi

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -155,7 +155,7 @@ device_chroot_tweaks_pre() {
 		[6.1.77]="5fc4f643d2e9c5aa972828705a902d184527ae3f|master|1730"
 	)
 	# Version we want
-	KERNEL_VERSION="5.10.95"
+	KERNEL_VERSION="6.1.77"
 
 	MAJOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d '.' -f 1)
 	MINOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d '.' -f 2)

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -34,7 +34,7 @@ BOOT_TYPE=msdos  # msdos or gpt
 INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs
-MODULES=("overlay" "squashfs" "fuse" "uas" "nls_cp437" "nls_iso8859_1")
+MODULES=("drm" "drm_panel_orientation_quirks" "fuse" "nls_cp437" "nls_iso8859_1" "overlay" "panel-ilitek-ili9881c" "panel-waveshare-dsi" "squashfs"  "uas")
 # Packages that will be installed
 PACKAGES=(
 	# Bluetooth packages

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -152,6 +152,7 @@ device_chroot_tweaks_pre() {
 		[6.1.64]="01145f0eb166cbc68dd2fe63740fac04d682133e|master|1702"
 		[6.1.69]="ec8e8136d773de83e313aaf983e664079cce2815|master|1710"
 		[6.1.70]="fc9319fda550a86dc6c23c12adda54a0f8163f22|master|1712"
+		[6.1.77]="5fc4f643d2e9c5aa972828705a902d184527ae3f|master|1730"
 	)
 	# Version we want
 	KERNEL_VERSION="5.10.95"

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -155,7 +155,7 @@ device_chroot_tweaks_pre() {
 		[6.1.77]="5fc4f643d2e9c5aa972828705a902d184527ae3f|master|1730"
 	)
 	# Version we want
-	KERNEL_VERSION="6.1.77"
+	KERNEL_VERSION="5.10.95"
 
 	MAJOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d '.' -f 1)
 	MINOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d '.' -f 2)

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -34,7 +34,7 @@ BOOT_TYPE=msdos  # msdos or gpt
 INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs
-MODULES=("overlay" "squashfs")
+MODULES=("overlay" "squashfs" "fuse" "uas")
 # Packages that will be installed
 PACKAGES=(
 	# Bluetooth packages

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -34,7 +34,7 @@ BOOT_TYPE=msdos  # msdos or gpt
 INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs
-MODULES=("overlay" "squashfs" "fuse" "uas")
+MODULES=("overlay" "squashfs" "fuse" "uas" "nls_cp437" "nls_iso8859_1")
 # Packages that will be installed
 PACKAGES=(
 	# Bluetooth packages

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -164,6 +164,7 @@ device_chroot_tweaks_pre() {
 	# List of custom firmware -
 	# github archives that can be extracted directly
 	declare -A CustomFirmware=(
+		[PiCustom]="https://raw.githubusercontent.com/Darmur/volumio-rpi-custom/main/output/modules-rpi-${KERNEL_VERSION}-custom.tar.gz"
 		[MotivoCustom]="https://github.com/volumio/motivo-drivers/raw/main/output/modules-rpi-${KERNEL_VERSION}-motivo.tar.gz"
 	)
 

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -346,6 +346,7 @@ device_chroot_tweaks_pre() {
 		dtparam=uart0=on
 		dtparam=uart1=off
 		dtoverlay=dwc2,dr_mode=host
+		otg_mode=1
 		dtoverlay=vc4-kms-v3d,cma-384,audio=off,noaudio=on
 	EOF
 

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -344,7 +344,7 @@ device_chroot_tweaks_pre() {
 		### APPLY CUSTOM PARAMETERS TO userconfig.txt ###
 		display_auto_detect=1
 		enable_uart=1
-		arm_64bit=0
+		arm_64bit=1
 		dtparam=uart0=on
 		dtparam=uart1=off
 		dtoverlay=dwc2,dr_mode=host

--- a/recipes/devices/cm4.sh
+++ b/recipes/devices/cm4.sh
@@ -343,6 +343,7 @@ device_chroot_tweaks_pre() {
 		### APPLY CUSTOM PARAMETERS TO userconfig.txt ###
 		display_auto_detect=1
 		enable_uart=1
+		arm_64bit=0
 		dtparam=uart0=on
 		dtparam=uart1=off
 		dtoverlay=dwc2,dr_mode=host

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -32,7 +32,7 @@ BOOT_TYPE=msdos  # msdos or gpt
 INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs
-MODULES=("overlay" "squashfs")
+MODULES=("overlay" "squashfs" "fuse" "uas")
 # Packages that will be installed
 PACKAGES=(# Bluetooth packages
 	"bluez" "bluez-firmware" "pi-bluetooth"

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -159,6 +159,7 @@ device_chroot_tweaks_pre() {
 		[6.1.64]="01145f0eb166cbc68dd2fe63740fac04d682133e|master|1702"
 		[6.1.69]="ec8e8136d773de83e313aaf983e664079cce2815|master|1710"
 		[6.1.70]="fc9319fda550a86dc6c23c12adda54a0f8163f22|master|1712"
+		[6.1.77]="5fc4f643d2e9c5aa972828705a902d184527ae3f|master|1730"
 	)
 	# Version we want
 	KERNEL_VERSION="6.1.69"

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -162,7 +162,7 @@ device_chroot_tweaks_pre() {
 		[6.1.77]="5fc4f643d2e9c5aa972828705a902d184527ae3f|master|1730"
 	)
 	# Version we want
-	KERNEL_VERSION="6.1.69"
+	KERNEL_VERSION="6.1.77"
 
 	MAJOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d '.' -f 1)
 	MINOR_VERSION=$(echo "$KERNEL_VERSION" | cut -d '.' -f 2)

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -32,7 +32,7 @@ BOOT_TYPE=msdos  # msdos or gpt
 INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs
-MODULES=("overlay" "squashfs" "fuse" "uas")
+MODULES=("overlay" "squashfs" "fuse" "uas" "nls_cp437" "nls_iso8859_1")
 # Packages that will be installed
 PACKAGES=(# Bluetooth packages
 	"bluez" "bluez-firmware" "pi-bluetooth"

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -363,6 +363,7 @@ device_chroot_tweaks_pre() {
 		### APPLY CUSTOM PARAMETERS TO userconfig.txt ###
 		[cm4]
 		dtoverlay=dwc2,dr_mode=host
+		otg_mode=1
 		[pi5]
 		dtoverlay=vc4-kms-v3d-pi5
 		[all]

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -13,7 +13,8 @@ declare -A SecureApt=(
 # Repo locations that are utilised to create source.list in the rootfs
 declare -A APTSOURCE=(
   [Debian]="http://deb.debian.org/debian"
-  [Raspbian]="http://raspbian.raspberrypi.org/raspbian/"
+  [Raspbian]="http://mirror.transip.net/raspbian/raspbian"
+  # [Raspbian]="http://raspbian.raspberrypi.org/raspbian/"
 )
 
 ## Path to the volumio repo

--- a/scripts/volumio/install-kiosk-vivaldi.sh
+++ b/scripts/volumio/install-kiosk-vivaldi.sh
@@ -18,6 +18,8 @@ CMP_PACKAGES=(
   "fonts-liberation" "libatk-bridge2.0-0" "libatk1.0-0" "libatspi2.0-0" "libgtk-3-0" "libnspr4" "libnss3" "xdg-utils"
   # Fonts
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
+  # Fonts for Japanese and Thai languages
+  "fonts-ipafont" "fonts-vlgothic" "fonts-thai-tlwg-ttf"
 )
 
 log "Installing ${#CMP_PACKAGES[@]} ${CMP_NAME} packages:" "" "${CMP_PACKAGES[*]}"

--- a/scripts/volumio/install-kiosk.sh
+++ b/scripts/volumio/install-kiosk.sh
@@ -19,6 +19,8 @@ CMP_PACKAGES=(
   "chromium" "chromium-l10n"
   # Fonts
   "fonts-arphic-ukai" "fonts-arphic-gbsn00lp" "fonts-unfonts-core"
+  # Fonts for Japanese and Thai languages
+  "fonts-ipafont" "fonts-vlgothic" "fonts-thai-tlwg-ttf"
 )
 
 log "Installing ${#CMP_PACKAGES[@]} ${CMP_NAME} packages:" "" "${CMP_PACKAGES[*]}"


### PR DESCRIPTION
A snapshot of master with the old init system prior migration to [`init-v3`]( https://github.com/volumio/volumio3-os/tree/dev/init-v3)


Please merge this just before the final migration to avoid multiple syncs from master. 