### PR TITLE
Locking mpd.socket as part of mpd.service

### DIFF
--- a/scripts/image/chrootconfig.sh
+++ b/scripts/image/chrootconfig.sh
@@ -137,7 +137,11 @@ systemctl disable mpd.service
 log "Copying MPD custom socket systemd file"
 [[ -d /usr/lib/systemd/system/ ]] || mkdir -p /usr/lib/systemd/system/
 ## TODO: FIND A MORE ELEGANT SOLUTION
-echo "[Socket]
+echo "[Unit]
+Description=Music Player Daemon Socket
+PartOf=mpd.service
+
+[Socket]
 ListenStream=%t/mpd/socket
 ListenStream=6600
 Backlog=5


### PR DESCRIPTION
   PartOf=
       Configures dependencies similar to Requires=, but limited to stopping and restarting of units. When systemd stops or restarts the units listed here, the action is propagated to this unit. Note that this is a one-way  dependency — changes to this unit do not affect the listed units.