### PR TITLE
Disarming vc4-kms-v3d in pi recipe

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -446,7 +446,6 @@ device_chroot_tweaks_pre() {
 		dtparam=nvme
 		dtparam=pciex1_gen=2
 		[all]
-		dtoverlay=vc4-kms-v3d
 		arm_64bit=0
 		dtparam=audio=on
 		audio_pwm_mode=2


### PR DESCRIPTION
Tested here:
https://community.volumio.com/t/volumio-3-beta-test-raspberry-pi-with-kernel-6-6/68784/74