### PR TITLE
Reverting raspberry pi recipe backport

### DIFF
--- a/installer/board-config/pi/mkinstall_config.sh
+++ b/installer/board-config/pi/mkinstall_config.sh
@@ -31,40 +31,7 @@ UUIDFMT="yes"			# yes|no (actually, anything non-blank)
 FACTORYCOPY="yes"
 
 # Modules to load (as a blank separated string array)
-MODULES=(
-	# Direct Rendering Manager with Plymouth
-	"drm" "drm_dma_helper" "drm_display_helper" "drm_kms_helper" "drm_panel_orientation_quirks" "drm_rp1_dsi" "drm_shmem_helper"
-	# Video DRM core
-	"v3d" "vc4"
-	# Video buffer
-	"videobuf2_v4l2" "videobuf2_common" "videobuf2_dma_contig" "v4l2_mem2mem" "videobuf2_memops"
-	# GPU scheduler
-	"gpu_sched"
-	# Platform encoders
-	"rpivid_hevc" "videodev"
-	# Backllight
-	"backlight" "gpio_backlight" "lm3630a_bl" "pwm_bl" "rpi_backlight"
-	# Bridge
-	"display_connector" "simple_bridge" "tc358762"
-	# Platform
-	"rpisense_fb" "ssd1307fb" "tc358762"
-	# DRM panels
-	"panel_ilitek_ili9806e" "panel_ilitek_ili9881c" "panel_jdi_lt070me05000" "panel_simple" "panel_sitronix_st7701" "panel_tdo_y17p" "panel_raspberrypi_touchscreen" "panel_waveshare_dsi"
-	# DRM tiny panels
-	"panel_mipi_dbi" "hx8357d" "ili9225" "ili9341" "ili9486" "repaper" "st7586" "st7735r"
-	# Power regulators
-	"rpi_panel_attiny_regulator" "rpi_panel_v2_regulator"
-	# i2c
-	"i2c_designware_core" "i2c_designware_platform" "i2c_dev" "i2c_gpio" "regmap_i2c" "ssd1307fb"
-	# USB
-	"udl"
-	# System
-	"fuse" "nls_cp437" "nls_iso8859_1" "nvme" "nvme_core" "overlay" "squashfs" "uas"
-	# Problematic clocks
-	"clk_hifiberry_dacpro" "clk_hifiberry_dachd"
-	# Problematic DACs
-	"snd_soc_hifiberry_adc" "snd_soc_hifiberry_dacplus" "snd_soc_hifiberry_dacplushd" "snd_soc_hifiberry_dacplusadc" "snd_soc_hifiberry_dacplusadcpro" "snd_soc_hifiberry_dacplusdsp"
-	"snd_soc_rpi_simple_soundcard" "snd_soc_rpi_wm8804_soundcard")
+MODULES=""drm" "fuse" "nls_cp437" "nls_iso8859_1" "nvme" "nvme_core" "overlay" "squashfs" "uas""
 
 # Additional packages to install (as a blank separated string)
 #PACKAGES=""

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -41,48 +41,15 @@ INIT_UUID_TYPE="pi" # Use block device GPEN if dynamic UUIDs are not handled.
 
 
 ## Plymouth theme management
-PLYMOUTH_THEME="volumio-player" # Choices are: {volumio,volumio-logo,volumio-player}
-INIT_PLYMOUTH_DISABLE="no"      # yes/no or empty. Removes plymouth initialization in init if "yes" is selected
+PLYMOUTH_THEME="volumio-player"	# Choices are: {volumio,volumio-logo,volumio-player}
+INIT_PLYMOUTH_DISABLE="no"		# yes/no or empty. Removes plymouth initialization in init if "yes" is selected
 
 ## TODO: for any KMS DRM panel mudule, which does not create frambuffer bridge, set this variable to yes, otherwise no
 ## Implement an if/else statement to handle this properly
-UPDATE_PLYMOUTH_SERVICES_FOR_KMS_DRM="yes" # yes/no or empty. Replaces default plymouth systemd services if "yes" is selected
+UPDATE_PLYMOUTH_SERVICES_FOR_KMS_DRM="no"	# yes/no or empty. Replaces default plymouth systemd services if "yes" is selected
 
 # Modules that will be added to initramfs
-MODULES=(
-	# Direct Rendering Manager with Plymouth
-	"drm" "drm_dma_helper" "drm_display_helper" "drm_kms_helper" "drm_panel_orientation_quirks" "drm_rp1_dsi" "drm_shmem_helper"
-	# Video DRM core
-	"v3d" "vc4"
-	# Video buffer
-	"videobuf2_v4l2" "videobuf2_common" "videobuf2_dma_contig" "v4l2_mem2mem" "videobuf2_memops"
-	# GPU scheduler
-	"gpu_sched"
-	# Platform encoders
-	"rpivid_hevc" "videodev"
-	# Backllight
-	"backlight" "gpio_backlight" "lm3630a_bl" "pwm_bl" "rpi_backlight"
-	# Bridge
-	"display_connector" "simple_bridge" "tc358762"
-	# Platform
-	"rpisense_fb" "ssd1307fb" "tc358762"
-	# DRM panels
-	"panel_ilitek_ili9806e" "panel_ilitek_ili9881c" "panel_jdi_lt070me05000" "panel_simple" "panel_sitronix_st7701" "panel_tdo_y17p" "panel_raspberrypi_touchscreen" "panel_waveshare_dsi"
-	# DRM tiny panels
-	"panel_mipi_dbi" "hx8357d" "ili9225" "ili9341" "ili9486" "repaper" "st7586" "st7735r"
-	# Power regulators
-	"rpi_panel_attiny_regulator" "rpi_panel_v2_regulator"
-	# i2c
-	"i2c_designware_core" "i2c_designware_platform" "i2c_dev" "i2c_gpio" "regmap_i2c" "ssd1307fb"
-	# USB
-	"udl"
-	# System
-	"fuse" "nls_cp437" "nls_iso8859_1" "nvme" "nvme_core" "overlay" "squashfs" "uas"
-	# Problematic clocks
-	"clk_hifiberry_dacpro" "clk_hifiberry_dachd"
-	# Problematic DACs
-	"snd_soc_hifiberry_adc" "snd_soc_hifiberry_dacplus" "snd_soc_hifiberry_dacplushd" "snd_soc_hifiberry_dacplusadc" "snd_soc_hifiberry_dacplusadcpro" "snd_soc_hifiberry_dacplusdsp"
-	"snd_soc_rpi_simple_soundcard" "snd_soc_rpi_wm8804_soundcard")
+MODULES=("drm" "fuse" "nls_cp437" "nls_iso8859_1" "nvme" "nvme_core" "overlay" "squashfs" "uas")
 # Packages that will be installed
 PACKAGES=( # Bluetooth packages
 	"bluez" "bluez-firmware" "pi-bluetooth"
@@ -442,6 +409,7 @@ device_chroot_tweaks_pre() {
 		dtoverlay=dwc2,dr_mode=host
 		otg_mode=1
 		[pi5]
+		dtoverlay=vc4-kms-v3d-pi5
 		# dtparam=uart0_console # Disabled by default
 		dtparam=nvme
 		dtparam=pciex1_gen=2
@@ -453,7 +421,6 @@ device_chroot_tweaks_pre() {
 		disable_splash=1
 		hdmi_force_hotplug=1
 		force_eeprom_read=0
-		display_auto_detect=1
 	EOF
 
 	log "Writing cmdline.txt file" "info"


### PR DESCRIPTION
The backported list breaks HDMI xorg functions