### PR TITLE
fix building on docker desktop for windows using WSL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ git
 jq
 kpartx
 libssl-dev
+lsb-release
 lz4
 lzop
 md5deep

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -59,16 +59,17 @@ log "Using DEBUG_IMAGE: ${DEBUG_IMAGE:-no}"
 VOLMNT=${MOUNT_DIR:-'/mnt/volumio'}
 IMAGE_END=${IMAGE_END:-2800}
 dd if=/dev/zero of="${IMG_FILE}" bs=1M count=$((IMAGE_END + 10))
-LOOP_DEV=$(losetup -f --show "${IMG_FILE}")
 
 # Note: leave the first 20Mb free for the firmware
-parted -s "${LOOP_DEV}" mklabel "${BOOT_TYPE}"
-parted -s "${LOOP_DEV}" mkpart primary fat32 "${BOOT_START:-0}" "${BOOT_END}"
-parted -s "${LOOP_DEV}" mkpart primary ext4 "${BOOT_END}" "${IMAGE_END}"
-parted -s "${LOOP_DEV}" mkpart primary ext4 "${IMAGE_END}" 100%
-parted -s "${LOOP_DEV}" set 1 boot on
-[[ "${BOOT_TYPE}" == gpt ]] && parted -s "${LOOP_DEV}" set 1 legacy_boot on # for non UEFI systems
-parted -s "${LOOP_DEV}" print
+parted -s "${IMG_FILE}" mklabel "${BOOT_TYPE}"
+parted -s "${IMG_FILE}" mkpart primary fat32 "${BOOT_START:-0}" "${BOOT_END}"
+parted -s "${IMG_FILE}" mkpart primary ext4 "${BOOT_END}" "${IMAGE_END}"
+parted -s "${IMG_FILE}" mkpart primary ext4 "${IMAGE_END}" 100%
+parted -s "${IMG_FILE}" set 1 boot on
+[[ "${BOOT_TYPE}" == gpt ]] && parted -s "${IMG_FILE}" set 1 legacy_boot on # for non UEFI systems
+parted -s "${IMG_FILE}" print
+
+LOOP_DEV=$(losetup -P -f --show "${IMG_FILE}")
 partprobe "${LOOP_DEV}"
 kpartx -a "${LOOP_DEV}" -s
 


### PR DESCRIPTION
Building image on windows using docker desktop was throwing following error

```
[ .... ] Stage [2]: Creating Image
[ .. ] Image file: .//Volumio--2024-10-17-mp1.img
[ .. ] Using DEBUG_IMAGE: no
3810+0 records in
3810+0 records out
3995074560 bytes (4.0 GB, 3.7 GiB) copied, 2.24278 s, 1.8 GB/s
Error: Partition(s) 1 on /dev/loop3 have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.
[ error ] Imagebuilder script failed!!
[ error ] Error stack [source] <= [main] <=  [ 66 /root/volumio3-os/scripts/makeimage.sh ]
```

This PR fixes the same. Also added lsb-release to the list of required packages as docker images doesn't have that installed by default and its needed by the build scripts.