### PR TITLE
Added udev rule which adds all usb devices to plugdev.

### DIFF
--- a/volumio/etc/udev/rules.d/09-hemdevices.rules
+++ b/volumio/etc/udev/rules.d/09-hemdevices.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", DRIVER=="usb", ATTR{idVendor}=="3336", MODE="0664", GROUP="plugdev"
+

--- a/volumio/etc/udev/rules.d/09-usb-devices-plugdev.rules
+++ b/volumio/etc/udev/rules.d/09-usb-devices-plugdev.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", DRIVER=="usb", MODE="0664", GROUP="plugdev"

--- a/volumio/etc/udev/rules.d/09-usb-devices-plugdev.rules
+++ b/volumio/etc/udev/rules.d/09-usb-devices-plugdev.rules
@@ -1,1 +1,0 @@
-SUBSYSTEMS=="usb", DRIVER=="usb", MODE="0664", GROUP="plugdev"


### PR DESCRIPTION
 It makes them accessible with volumio user rights and plugins can scan them to find supported ones.